### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sentence-splitter==1.4
 spacy==3.4.1
 nltk==3.7
 scikit-learn==1.1.1
-evaluate==0.2.2
+evaluate==0.3.0
 scipy==1.9.0
 laserembeddings==1.1.2
 torchmetrics==0.9.3


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.